### PR TITLE
Simplified use of ActionManager enums

### DIFF
--- a/LuteBot/UI/LuteBotForm.cs
+++ b/LuteBot/UI/LuteBotForm.cs
@@ -236,7 +236,8 @@ namespace LuteBot
             }
             else
             {
-                if (ActionManager.AutoConsoleModeFromString(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode)) == ActionManager.AutoConsoleMode.Old)
+                Enum.TryParse<ActionManager.AutoConsoleMode>(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode), out ActionManager.AutoConsoleMode consoleMode);
+                if (consoleMode == ActionManager.AutoConsoleMode.Old)
                 {
                     ActionManager.ToggleConsole(false);
                 }
@@ -391,7 +392,8 @@ namespace LuteBot
 
         private void Play()
         {
-            if (ActionManager.AutoConsoleModeFromString(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode)) == ActionManager.AutoConsoleMode.Old)
+            Enum.TryParse<ActionManager.AutoConsoleMode>(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode), out ActionManager.AutoConsoleMode consoleMode);
+            if (consoleMode == ActionManager.AutoConsoleMode.Old)
             {
                 ActionManager.ToggleConsole(true);
             }
@@ -403,7 +405,8 @@ namespace LuteBot
 
         private void Pause()
         {
-            if (ActionManager.AutoConsoleModeFromString(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode)) == ActionManager.AutoConsoleMode.Old)
+            Enum.TryParse<ActionManager.AutoConsoleMode>(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode), out ActionManager.AutoConsoleMode consoleMode);
+            if (consoleMode == ActionManager.AutoConsoleMode.Old)
             {
                 ActionManager.ToggleConsole(false);
             }

--- a/LuteBot/UI/SettingsForm.cs
+++ b/LuteBot/UI/SettingsForm.cs
@@ -198,7 +198,8 @@ namespace LuteBot
 
         private void InitRadioButtons()
         {
-            ActionManager.AutoConsoleMode consoleMode = ActionManager.AutoConsoleModeFromString(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode));
+            Enum.TryParse<ActionManager.AutoConsoleMode>(ConfigManager.GetProperty(PropertyItem.ConsoleOpenMode), out ActionManager.AutoConsoleMode consoleMode);
+            Console.WriteLine(consoleMode);
             switch (consoleMode)
             {
                 case ActionManager.AutoConsoleMode.New:
@@ -223,7 +224,7 @@ namespace LuteBot
         {
             if (OldAutoConsoleRadio.Checked)
             {
-                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleModeToString(ActionManager.AutoConsoleMode.Old));
+                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleMode.Old.ToString());
                 NewAutoConsoleRadio.Checked = false;
                 OffAutoConsoleRadio.Checked = false;
             }
@@ -233,7 +234,7 @@ namespace LuteBot
         {
             if (NewAutoConsoleRadio.Checked)
             {
-                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleModeToString(ActionManager.AutoConsoleMode.New));
+                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleMode.New.ToString());
                 OldAutoConsoleRadio.Checked = false;
                 OffAutoConsoleRadio.Checked = false;
             }
@@ -243,7 +244,7 @@ namespace LuteBot
         {
             if (OffAutoConsoleRadio.Checked)
             {
-                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleModeToString(ActionManager.AutoConsoleMode.Off));
+                ConfigManager.SetProperty(PropertyItem.ConsoleOpenMode, ActionManager.AutoConsoleMode.Off.ToString());
                 NewAutoConsoleRadio.Checked = false;
                 OldAutoConsoleRadio.Checked = false;
             }


### PR DESCRIPTION
Just a pull request to replace the "ConsoleModeFromString" and "ConsoleModeToString" methods with standard enum methods which do the same.
Addtionally switched the loops in the input command method for shorter code.