### PR TITLE
Fixed null pointer message for filtered channels

### DIFF
--- a/LuteBot/Core/Midi/MidiPlayer.cs
+++ b/LuteBot/Core/Midi/MidiPlayer.cs
@@ -198,22 +198,25 @@ namespace LuteBot.Core.Midi
 
         private void HandleChannelMessagePlayed(object sender, ChannelMessageEventArgs e)
         {
-            if (ConfigManager.GetProperty(PropertyItem.NoteConversionMode) != "1")
+            ChannelMessage msg = trackSelectionManager.FilterMidiEvent(e.Message);
+            if (msg != null)
             {
-                if (ConfigManager.GetBooleanProperty(PropertyItem.SoundEffects) && !disposed)
+                if (ConfigManager.GetProperty(PropertyItem.NoteConversionMode) != "1")
                 {
-                    outDevice.Send(mordhauOutDevice.FilterNote(trackSelectionManager.FilterMidiEvent(e.Message)));
+                    if (ConfigManager.GetBooleanProperty(PropertyItem.SoundEffects) && !disposed)
+                    {
+                        outDevice.Send(mordhauOutDevice.FilterNote(msg));
+                    }
+                    else
+                    {
+                        mordhauOutDevice.SendNote(msg);
+                    }
                 }
                 else
                 {
-                    mordhauOutDevice.SendNote(trackSelectionManager.FilterMidiEvent(e.Message));
+                    outDevice.Send(msg);
                 }
             }
-            else
-            {
-                outDevice.Send(trackSelectionManager.FilterMidiEvent(e.Message));
-            }
-
         }
 
         private void HandlePlayingCompleted(object sender, EventArgs e)

--- a/LuteBot/Core/MordhauOutDevice.cs
+++ b/LuteBot/Core/MordhauOutDevice.cs
@@ -103,7 +103,7 @@ namespace LuteBot.Core
 
         public void SendNote(ChannelMessage message)
         {
-            if (message.Command == ChannelCommand.NoteOn && message.Data2 > 0)
+            if (message != null && message.Command == ChannelCommand.NoteOn && message.Data2 > 0)
             {
                 int noteCooldown = int.Parse(ConfigManager.GetProperty(PropertyItem.NoteCooldown));
                 if (cooldownNeeded)


### PR DESCRIPTION
This fixes a bug caused by a null pointer.

Steps to reproduce the bug without the fix:
1. Open a midi file
2. Enable sound effects (midi gets played from the app)
3. Start playing the midi in the app
4. Open Track Selection window
5. Disable any of the tracks
6. App crashes because of a null pointer message